### PR TITLE
docs: add usage example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,17 @@ at your option.
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
+
+## Usage Example
+
+Here’s a quick example of how to use the `seek` SDK:
+
+```bash
+cargo add seek
+
+use seek;
+
+fn main() {
+    // Example usage
+    println!("Seek SDK is ready!");
+}


### PR DESCRIPTION
This PR improves the README.md by adding a Usage Example section.

Changes introduced:

- Added installation instruction (cargo add seek)
- Added a minimal Rust code snippet demonstrating how to use the seek SDK

Motivation:
Including a quick usage example makes it easier for new users and contributors to get started with the SDK without having to dig into the codebase.

Related Issue

Closes #20